### PR TITLE
revise the payments section of the website

### DIFF
--- a/index.html
+++ b/index.html
@@ -207,7 +207,7 @@
 			<section class="content-unit">
 				<div class="wrap">
 					<h2 class="unit-title">Join</h2>
-					<p class="summary">Come hang out any weekday and meet some members. If you'd like to use the space beyond the day, we operate on monthly recurring donations.</p>
+					<p class="summary">Come hang out any weekday and meet some members. If you'd like to use the space beyond the day, we operate on the honor system with monthly recurring payments through PayPal:</p>
 					<div class="clearfix">
 
 						<div class="sixcol first">
@@ -251,6 +251,10 @@
 							</div>
 						</div> <!-- /.sixcol -->
 					</div>
+
+                    <p class="summary">... or name your price <a
+                        href="https://gratipay.com/catapultpgh">on Gratipay</a>
+                    (<i>weekly</i> recurring).</p>
 
 				</div> <!-- /.wrap -->
 

--- a/index.html
+++ b/index.html
@@ -209,110 +209,48 @@
 					<h2 class="unit-title">Join</h2>
 					<p class="summary">Come hang out any weekday and meet some members. If you'd like to use the space beyond the day, we operate on monthly recurring donations.</p>
 					<div class="clearfix">
+
 						<div class="sixcol first">
 							<div class="perk">
-								<h5>Membership <span class="price">$10-100/month</span></h5>
-                <p>Membership is donation based. Some people take a little, some people take a lot. Follow your feelings.</p>
+								<h5>Flex Desk <span class="price">$75/month</span></h5>
 
-                <form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_top">
-<input type="hidden" name="cmd" value="_s-xclick">
-<input type="hidden" name="hosted_button_id" value="3BB9N9W8QE2NY">
-<table>
-<tr><td><input type="hidden" name="on0" value=""></td></tr><tr><td><select name="os0">
-	<option value="Option 1">Option 1 : $10.00 USD - monthly</option>
-	<option value="Option 2">Option 2 : $20.00 USD - monthly</option>
-	<option value="Option 3">Option 3 : $30.00 USD - monthly</option>
-	<option value="Option 4">Option 4 : $40.00 USD - monthly</option>
-	<option value="Option 5">Option 5 : $50.00 USD - monthly</option>
-	<option value="Option 6">Option 6 : $60.00 USD - monthly</option>
-	<option value="Option 7">Option 7 : $70.00 USD - monthly</option>
-	<option value="Option 8">Option 8 : $80.00 USD - monthly</option>
-	<option value="Option 9">Option 9 : $90.00 USD - monthly</option>
-	<option value="Option 10">Option 10 : $100.00 USD - monthly</option>
-</select> </td></tr>
-</table>
-<input type="hidden" name="currency_code" value="USD">
-<input type="image" src="https://www.paypalobjects.com/en_US/i/btn/btn_subscribe_LG.gif" border="0" name="submit" alt="PayPal - The safer, easier way to pay online!">
-</form>
-
-
-
-
-							</div>
-						</div> <!-- /.sixcol -->
-					<div class="clearfix">
-						<div class="sixcol last">
-							<div class="perk">
-								<h5>Membership <span class="price">$110-200/month</span></h5>
-                <p>Membership is donation based. Some people take a little, some people take a lot. Follow your feelings.</p>
 <form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_top">
-<input type="hidden" name="cmd" value="_s-xclick">
-<input type="hidden" name="hosted_button_id" value="CYJMBTY38XQLU">
-<table>
-<tr><td><input type="hidden" name="on0" value=""></td></tr><tr><td><select name="os0">
-	<option value="Option 1">Option 1 : $110.00 USD - monthly</option>
-	<option value="Option 2">Option 2 : $120.00 USD - monthly</option>
-	<option value="Option 3">Option 3 : $130.00 USD - monthly</option>
-	<option value="Option 4">Option 4 : $140.00 USD - monthly</option>
-	<option value="Option 5">Option 5 : $150.00 USD - monthly</option>
-	<option value="Option 6">Option 6 : $160.00 USD - monthly</option>
-	<option value="Option 7">Option 7 : $170.00 USD - monthly</option>
-	<option value="Option 8">Option 8 : $180.00 USD - monthly</option>
-	<option value="Option 9">Option 9 : $190.00 USD - monthly</option>
-	<option value="Option 10">Option 10 : $200.00 USD - monthly</option>
-</select> </td></tr>
-</table>
-<input type="hidden" name="currency_code" value="USD">
-<input type="image" src="https://www.paypalobjects.com/en_US/i/btn/btn_subscribe_LG.gif" border="0" name="submit" alt="PayPal - The safer, easier way to pay online!">
+    <input type="hidden" name="cmd" value="_xclick-subscriptions">
+    <input type="hidden" name="business" value="money@catapultpgh.org">
+    <input type="hidden" name="currency_code" value="USD">
+    <input type="hidden" name="a3" value="75">
+    <input type="hidden" name="p3" value="1">
+    <input type="hidden" name="t3" value="M">
+    <input type="hidden" name="no_note" value="1">
+    <input type="hidden" name="src" value="1">
+    <input type="hidden" name="item_name" value="Monthly Flex Desk Subscription at Catapult">
+    <br>
+    <input type="image" src="https://www.paypalobjects.com/webstatic/en_US/btn/btn_subscribe_113x26.png" border="0" name="submit" alt="PayPal - The safer, easier way to pay online!">
 </form>
-
 
 							</div>
 						</div> <!-- /.sixcol -->
-					<div class="clearfix">
-						<div class="sixcol first">
+						<div class="sixcol">
 							<div class="perk">
-								<h5>Membership <span class="price">$250-900/month</span></h5>
-                <p>Membership is donation based. Some people take a little, some people take a lot. Follow your feelings.</p>
-                
+								<h5>Fixed Desk <span class="price">$150/month</span></h5>
+
 <form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_top">
-<input type="hidden" name="cmd" value="_s-xclick">
-<input type="hidden" name="hosted_button_id" value="MQKRGE3K65WMN">
-<table>
-<tr><td><input type="hidden" name="on0" value=""></td></tr><tr><td><select name="os0">
-	<option value="Option 1">Option 1 : $250.00 USD - monthly</option>
-	<option value="Option 2">Option 2 : $300.00 USD - monthly</option>
-	<option value="Option 3">Option 3 : $350.00 USD - monthly</option>
-	<option value="Option 4">Option 4 : $400.00 USD - monthly</option>
-	<option value="Option 5">Option 5 : $450.00 USD - monthly</option>
-	<option value="Option 6">Option 6 : $500.00 USD - monthly</option>
-	<option value="Option 7">Option 7 : $600.00 USD - monthly</option>
-	<option value="Option 8">Option 8 : $700.00 USD - monthly</option>
-	<option value="Option 9">Option 9 : $800.00 USD - monthly</option>
-	<option value="Option 10">Option 10 : $900.00 USD - monthly</option>
-</select> </td></tr>
-</table>
-<input type="hidden" name="currency_code" value="USD">
-<input type="image" src="https://www.paypalobjects.com/en_US/i/btn/btn_subscribe_LG.gif" border="0" name="submit" alt="PayPal - The safer, easier way to pay online!">
+    <input type="hidden" name="cmd" value="_xclick-subscriptions">
+    <input type="hidden" name="business" value="money@catapultpgh.org">
+    <input type="hidden" name="currency_code" value="USD">
+    <input type="hidden" name="a3" value="150">
+    <input type="hidden" name="p3" value="1">
+    <input type="hidden" name="t3" value="M">
+    <input type="hidden" name="no_note" value="1">
+    <input type="hidden" name="src" value="1">
+    <input type="hidden" name="item_name" value="Monthly Fixed Desk Subscription at Catapult">
+    <br>
+    <input type="image" src="https://www.paypalobjects.com/webstatic/en_US/btn/btn_subscribe_113x26.png" border="0" name="submit" alt="PayPal - The safer, easier way to pay online!">
 </form>
 
-
 							</div>
 						</div> <!-- /.sixcol -->
-						<div class="sixcol last">
-							<div class="perk">
-								<h5>One Time Donation<span class="price"></span></h5>
-                <p>If you come for a day, or two, or have a beer on us, this is a good idea.</p>
-
-                <form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_top">
-                  <input type="hidden" name="cmd" value="_s-xclick">
-                  <input type="hidden" name="hosted_button_id" value="3DN7EXU4KLGGE">
-                  <input type="image" src="https://www.paypalobjects.com/en_US/i/btn/btn_donate_LG.gif" border="0" name="submit" alt="PayPal - The safer, easier way to pay online!">
-                </form>
-
-							</div>
-						</div> <!-- /.sixcol -->
-					</div> 
+					</div>
 
 				</div> <!-- /.wrap -->
 


### PR DESCRIPTION
For [three years](https://web.archive.org/web/20130416011509/http://catapultpgh.org/news/2013/3/22/show-n-tell-11-the-brew-gentlemen-cellhelmet-art-all-night-g.html) now, [Gratipay](https://gratipay.com/) (formerly Gittip) has been a way to pay for your Catapult membership. Some of you may recall an unfortunate and really disruptive [crisis](https://gratipay.news/gratipocalypse-42fd0ec0d9e8) that Gratipay went through last year, which made it not so good of an option for Catapult for a while. I'm really sorry about that. :disappointed: 

@kaguillera and I, two folks working on Gratipay (I'm the founder), have been coworking at Catapult most Thursdays for [going on](https://github.com/gratipay/inside.gratipay.com/issues/368#issuecomment-148176750) six months now. We're using Gratipay to pay for our membership, and we'd like to formally offer it to the rest of the Catapult community as a way to pay for your membership, too. I'd like to emphasize that this is an _option_ and in no way a hard cut-over (as I believe we saw more recently from Memberful to PayPal?). If you don't have time or inclination to figure out Gratipay, please keep using PayPal! Gratipay is for early adopters. :-)

This so-called "pull request" (PR) updates the "Join" section of the Catapult homepage to add a link to Gratipay (those of you who have been in the space recently may have noticed a foreshadowing on the whiteboard towards the front ;). Again, this is **in addition** to the PayPal buttons. This PR also simplifies the PayPal buttons down to just two options, based on the most common types of Catapult membership. Screenshots of the change are included below. I welcome your feedback either here on GitHub, or in Slack.

Thanks for considering this change! :-)
# Foreshadowing

![photo on 3-24-16 at 5 13 pm](https://cloud.githubusercontent.com/assets/134455/14031613/f4db8326-f1e3-11e5-8e3b-a1e862312a22.jpg)
# Before

![screen shot 2016-03-24 at 4 51 40 pm](https://cloud.githubusercontent.com/assets/134455/14031809/0b019856-f1e5-11e5-98a5-0670f4003f22.png)

![screen shot 2016-03-24 at 4 53 45 pm](https://cloud.githubusercontent.com/assets/134455/14031815/141b337a-f1e5-11e5-9454-f850d8fe07da.png)
# After

(Please ignore the typography differences, that's an artifact of loading the page locally in development.)

![screen shot 2016-03-24 at 5 04 18 pm](https://cloud.githubusercontent.com/assets/134455/14031822/1ebc2730-f1e5-11e5-8b5b-386352651cd9.png)

![screen shot 2016-03-24 at 4 53 38 pm](https://cloud.githubusercontent.com/assets/134455/14031826/289c7e44-f1e5-11e5-9323-71b29ae99dff.png)

P.S. Here's the PayPal [docs](https://developer.paypal.com/docs/classic/paypal-payments-standard/integration-guide/Appx_websitestandard_htmlvariables/#id08A6HI00JQU) and [buttons](https://developer.paypal.com/docs/classic/api/buttons/) I used.
